### PR TITLE
bugfix: legacy configs with comments were not properly converted

### DIFF
--- a/src/core/config_legacy.c
+++ b/src/core/config_legacy.c
@@ -100,11 +100,27 @@ static char* relativize_to_dir(const char *path, const char *dst_dir) {
     return xstrdup(real_path);
 }
 
+static void strip_inline_comment(char *s) {
+    if (!s) return;
+    /* Remove comments starting with '#' when at BOL or preceded by whitespace. */
+    char *p = s;
+    while (*p) {
+        if (*p == '#') {
+            int at_bol = (p == s);
+            int prev_ws = (!at_bol && (p[-1] == ' ' || p[-1] == '\t'));
+            if (at_bol || prev_ws) { *p = '\0'; break; }
+        }
+        p++;
+    }
+}
+
 static int parse_line(char *line, int *lineno, legacy_cfg_t *cfg) {
     (void)lineno;
+    /* Strip inline comments first */
+    strip_inline_comment(line);
     /* Strip leading spaces */
     char *p = line; while (*p == ' ' || *p == '\t') p++;
-    if (*p == '\0' || *p == '#' || *p == '\n' || *p == '\r') return 0;
+    if (*p == '\0' || *p == '\n' || *p == '\r') return 0;
     char *cmd = strtok(p, " \t\r\n");
     if (!cmd) return 0;
     if (strcmp(cmd, "layer") == 0) {
@@ -205,4 +221,3 @@ int legacy_paths_default(char *legacy_path, size_t lsz, char *toml_path, size_t 
         snprintf(toml_path, tsz, "%s/.config/hyprlax/hyprlax.toml", home);
     return 0;
 }
-

--- a/tests/test_convert_config_comments.sh
+++ b/tests/test_convert_config_comments.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat >"$tmpdir/parallax.conf" <<'CONF'
+# Leading comment line
+layer ./bg.png         # comment after path; defaults for shift/opacity/blur
+layer ./fg.png 0.6 0.9 # comment after values
+
+# Global settings with inline comments
+duration 1.5  # seconds
+shift 200     # pixels
+easing sine   # type
+fps 120       # rate
+vsync 1       # boolean
+idle_poll_rate 2.0 # hz
+scale 1.1 # global scale
+CONF
+
+touch "$tmpdir/bg.png" "$tmpdir/fg.png"
+
+dst="$tmpdir/hyprlax.toml"
+
+echo "Converting legacy with inline comments ..."
+"$PWD"/hyprlax ctl convert-config "$tmpdir/parallax.conf" "$dst" --yes >/dev/null
+
+test -f "$dst" || { echo "FAIL: TOML not created"; exit 1; }
+
+echo "Asserting TOML contents ..."
+grep -q "\\[global\\]" "$dst" || { echo "FAIL: missing [global]"; exit 1; }
+grep -q "duration = 1.500" "$dst" || { echo "FAIL: missing/incorrect duration"; exit 1; }
+grep -q "shift = 200.000" "$dst" || { echo "FAIL: missing/incorrect shift"; exit 1; }
+grep -q "easing = \"sine\"" "$dst" || { echo "FAIL: missing/incorrect easing"; exit 1; }
+grep -q "fps = 120" "$dst" || { echo "FAIL: missing/incorrect fps"; exit 1; }
+grep -q "vsync = true" "$dst" || { echo "FAIL: missing/incorrect vsync"; exit 1; }
+grep -q "idle_poll_rate = 2.000" "$dst" || { echo "FAIL: missing/incorrect idle_poll_rate"; exit 1; }
+grep -q "scale = 1.100" "$dst" || { echo "FAIL: missing/incorrect scale"; exit 1; }
+
+# Expect two layer blocks
+layers_count=$(grep -c "^\[\[global.layers\]\]$" "$dst")
+test "$layers_count" -eq 2 || { echo "FAIL: expected 2 layers, got $layers_count"; exit 1; }
+
+# bg.png should have defaults applied (1.000 for shift_multiplier and opacity)
+grep -q "path = \"bg.png\"" "$dst" || { echo "FAIL: missing bg.png layer"; exit 1; }
+grep -q "shift_multiplier = 1.000" "$dst" || { echo "FAIL: bg.png default shift_multiplier not applied"; exit 1; }
+grep -q "opacity = 1.000" "$dst" || { echo "FAIL: bg.png default opacity not applied"; exit 1; }
+
+# fg.png should have provided values (0.6, 0.9)
+grep -q "path = \"fg.png\"" "$dst" || { echo "FAIL: missing fg.png layer"; exit 1; }
+grep -q "shift_multiplier = 0.600" "$dst" || { echo "FAIL: fg.png shift_multiplier incorrect"; exit 1; }
+grep -q "opacity = 0.900" "$dst" || { echo "FAIL: fg.png opacity incorrect"; exit 1; }
+
+echo "PASS: convert-config handles inline comments"
+


### PR DESCRIPTION
## Description
Fixed an issue where legacy configuration files (.conf) with inline comments were not properly converted to the new TOML format. The parser was not stripping inline comments before processing values, causing conversion failures.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Platform/Compositor/Renderer support
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issue
<!-- No related issue found -->

## Changes Made
- Added `strip_inline_comment()` function to remove inline comments from legacy config lines
- Modified `parse_line()` to strip inline comments before processing configuration values
- Added comprehensive test script to verify inline comment handling during conversion

## Testing
- [x] Manually tested the changes
- [x] Added new test script `test_convert_config_comments.sh` that verifies:
  - Comments are properly stripped from layer definitions
  - Comments are properly stripped from global settings
  - Converted TOML output contains correct values without comment text
  - Default values are properly applied when not specified

## Checklist

### Code Quality
- [x] My code follows the style and conventions of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

### Testing
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

### Documentation
- [ ] I have updated the documentation accordingly (N/A - bugfix only)
- [ ] I have updated the README if needed (N/A - no user-facing changes)
- [ ] I have updated CHANGELOG.md (TODO if required)

### Focus
- [x] This PR focuses on a single change/feature/fix
- [x] No unrelated changes are included
- [x] All changes are necessary for the stated purpose

## Screenshots
<!-- Not applicable for this bugfix -->

## Additional Notes
This fix ensures that users migrating from legacy configuration files with inline comments (using `#`) will have their configs properly converted to the new TOML format. The fix handles comments that appear after configuration values on the same line, which was previously causing the parser to fail.