### PR TITLE
fix: fractional scaling over-zooms wallpaper (closes #87)

### DIFF
--- a/src/core/render_core.c
+++ b/src/core/render_core.c
@@ -104,10 +104,12 @@ static void hyprlax_render_monitor(hyprlax_context_t *ctx, monitor_instance_t *m
         LOG_ERROR("Failed to make EGL surface current for monitor %s", monitor->name);
         return;
     }
-    double eff_scale = monitor_get_effective_scale(monitor);
-    int vp_width = (int)ceil(monitor->width * eff_scale);
-    int vp_height = (int)ceil(monitor->height * eff_scale);
-    glViewport(0, 0, vp_width, vp_height);
+    /* monitor->width / monitor->height come from wl_output.mode and are
+     * already in physical scanout pixels — they match the buffer size we
+     * allocate in wayland_create_monitor_surface / fractional_scale_preferred.
+     * Multiplying by eff_scale here would render to a region 1.5× the buffer
+     * on fractional outputs, clipping the rest and producing visible zoom. */
+    glViewport(0, 0, monitor->width, monitor->height);
 
     RENDERER_BEGIN_FRAME(ctx->renderer);
     /* Frame prep: either clear (default) or fade previous frame for trails */

--- a/src/platform/wayland.c
+++ b/src/platform/wayland.c
@@ -655,11 +655,23 @@ static void fractional_scale_preferred(void *data,
     /* Check if scale is truly fractional (not integer) */
     bool is_fractional = (scale_times_120 % 120) != 0;
 
-    /* Resize EGL window to match new physical pixel dimensions */
+    /* Resize EGL window to match the physical pixel dimensions of the surface.
+     *
+     * monitor->width / monitor->height are populated from wl_output.mode,
+     * which the protocol defines as physical scanout pixels. The buffer
+     * therefore must be exactly that size — multiplying by the fractional
+     * scale (the previous behavior) over-sizes the buffer by `new_scale`
+     * and the wallpaper visibly zooms in by the same factor.
+     *
+     * The viewport's destination is the *logical* surface size, which is
+     * physical / fractional_scale.
+     */
     if (monitor->wl_egl_window && monitor->width > 0 && monitor->height > 0) {
-        int phys_w = (int)ceil(monitor->width * new_scale);
-        int phys_h = (int)ceil(monitor->height * new_scale);
-        wl_egl_window_resize(monitor->wl_egl_window, phys_w, phys_h, 0, 0);
+        int buffer_w = monitor->width;
+        int buffer_h = monitor->height;
+        int logical_w = (int)lround(monitor->width / new_scale);
+        int logical_h = (int)lround(monitor->height / new_scale);
+        wl_egl_window_resize(monitor->wl_egl_window, buffer_w, buffer_h, 0, 0);
 
         if (is_fractional) {
             /* Fractional scale: need viewport to set logical surface size,
@@ -675,7 +687,7 @@ static void fractional_scale_preferred(void *data,
             }
             if (monitor->wp_viewport) {
                 wp_viewport_set_destination((struct wp_viewport *)monitor->wp_viewport,
-                                           monitor->width, monitor->height);
+                                           logical_w, logical_h);
             }
         } else {
             /* Integer scale: no viewport needed, existing integer scale
@@ -685,7 +697,7 @@ static void fractional_scale_preferred(void *data,
         }
 
         LOG_DEBUG("Monitor %s: resized EGL window to %dx%d (logical %dx%d, scale %.4f, fractional=%d)",
-                  monitor->name, phys_w, phys_h, monitor->width, monitor->height, new_scale, is_fractional);
+                  monitor->name, buffer_w, buffer_h, logical_w, logical_h, new_scale, is_fractional);
     }
 }
 
@@ -775,14 +787,17 @@ int wayland_create_monitor_surface(monitor_instance_t *monitor) {
         }
     }
 
-    /* Create EGL window for this surface */
+    /* Create EGL window for this surface.
+     *
+     * monitor->width / monitor->height come from wl_output.mode — physical
+     * scanout pixels per protocol — so the buffer must be exactly that size.
+     * If a fractional scale arrives later, fractional_scale_preferred resizes
+     * the EGL window (still to physical) and creates a viewport with
+     * destination = logical. */
     if (monitor->wl_surface) {
-        double eff_scale = monitor_get_effective_scale(monitor);
-        int phys_w = (int)ceil(monitor->width * eff_scale);
-        int phys_h = (int)ceil(monitor->height * eff_scale);
         monitor->wl_egl_window = wl_egl_window_create(
             monitor->wl_surface,
-            phys_w, phys_h);
+            monitor->width, monitor->height);
 
         if (!monitor->wl_egl_window) {
             LOG_ERROR("Failed to create EGL window for monitor %s", monitor->name);


### PR DESCRIPTION
Closes #87.

Fixes the fractional-DPI over-zoom that #84 / #79 thought they had resolved. Two sites of the same mistake — `monitor->width/height` come from `wl_output.mode` and are physical scanout pixels per protocol, not logical:

- `src/platform/wayland.c::fractional_scale_preferred()` was sizing the EGL buffer as `monitor->width * scale` (giving 1.5× oversized buffers on a 1.5× output) and setting the viewport destination to physical instead of logical. Now: buffer = physical, viewport destination = `round(physical / scale)` = logical. Initial EGL window creation in `wayland_create_monitor_surface()` got the same correction.
- `src/core/render_core.c::render_for_monitor()` was calling `glViewport` with `(monitor->width * scale, monitor->height * scale)`, rendering 1.5× larger than the buffer can hold and clipping the rest. Now uses `(monitor->width, monitor->height)`, matching the buffer.

Both sites have to land together: the `render_core.c` bug actually masks the `wayland.c` bug — so a wayland-only patch makes the visible zoom slightly worse before this lands.

Bug only manifests at non-integer scales — at integer scale 1 the multiplications are no-ops, which is why it slipped past v2.2.1.

### Verification

Live-tested on Hyprland with a 4K (3840×2160) Vizio output at scales 1.0, 1.5, 1.6667, 1.75. Each transition was triggered with `hyprctl keyword monitor "DP-1,3840x2160@60,0x0,<S>,bitdepth,10"` and visually confirmed correct sizing on the display, plus debug-log spot-checks of the resize numbers, e.g. at scale 1.5:

```
Monitor DP-1: fractional scale preferred: 1.5000 (raw: 180/120)
Created viewport for monitor DP-1 (fractional scale 1.5000)
Monitor DP-1: resized EGL window to 3840x2160 (logical 2560x1440, scale 1.5000, fractional=1)
```

(was `5760x3240 (logical 3840x2160, …)` before this PR.)

Single-monitor and dual-monitor configs both behave correctly. Did not retest the `niri` / `sway` / non-Hyprland paths — none of these changes touch compositor-specific code, but a second pair of eyes on those would be welcome.

### Out of scope

There's a separate IPC-wedge bug where hyprlax stops processing workspace events after a monitor add/remove (lid close, `hyprctl monitor … disable`). Will file separately if I get a clean repro for it.
