### PR TITLE
Fix hotplug monitor lifecycle and renderer churn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 hyprlax
 hyprlax-ctl
 *.o
+*.d
 *.a
 *.so
 
@@ -32,6 +33,7 @@ vgcore.*
 # Test files
 tests/test_*
 !tests/test_*.c
+!tests/test_*.sh
 *.test
 test_config/
 

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,7 @@ SRCS = $(MAIN_SRCS) src/ipc.c $(CORE_SRCS) $(RENDERER_SRCS) $(PLATFORM_SRCS) \
 #SRCS += src/vendor/toml.c src/core/config_toml.c src/core/config_legacy.c
 SRCS += src/vendor/toml.c src/vendor/gifdec.c src/core/config_toml.c src/core/config_legacy.c
 OBJS = $(SRCS:.c=.o)
+DEPS = $(OBJS:.o=.d)
 TARGET = hyprlax
 
 all: $(TARGET)
@@ -212,7 +213,7 @@ protocols/viewporter-client-protocol.h: $(VIEWPORTER_PROTOCOL)
 # Compile
 %.o: %.c $(PROTOCOL_HDRS)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(PKG_CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) $(PKG_CFLAGS) -MMD -MP -c $< -o $@
 
 # Ensure VERSION file exists before building
 VERSION:
@@ -224,8 +225,10 @@ $(TARGET): VERSION $(OBJS)
 	$(CC) $(LDFLAGS) $(OBJS) $(PKG_LIBS) -lm -o $@
 
 clean:
-	rm -f $(TARGET) $(OBJS) $(PROTOCOL_SRCS) $(PROTOCOL_HDRS)
-	rm -rf protocols/*.o src/*.o
+	rm -f $(TARGET) $(OBJS) $(DEPS) $(PROTOCOL_SRCS) $(PROTOCOL_HDRS)
+	rm -rf protocols/*.o protocols/*.d src/*.o src/*.d
+
+-include $(DEPS)
 
 PREFIX ?= /usr/local
 BINDIR = $(PREFIX)/bin
@@ -252,6 +255,8 @@ TEST_LIBS = $(CHECK_LIBS) -lm
 # Valgrind settings for memory leak detection
 VALGRIND = valgrind
 VALGRIND_FLAGS = --leak-check=full --show-leak-kinds=definite,indirect --track-origins=yes --error-exitcode=1
+MEMCHECK_CFLAGS = -Wall -Wextra -O2 -flto -Isrc -Isrc/include -DHYPRLAX_VERSION=\"$(VERSION)\" $(BUILD_DEFINES)
+MEMCHECK_LDFLAGS = -flto
 # For Arch Linux, enable debuginfod for symbol resolution
 export DEBUGINFOD_URLS ?= https://debuginfod.archlinux.org
 
@@ -364,6 +369,11 @@ tests/test_resource_monitor: tests/test_resource_monitor.c \
     src/core/resource_monitor.c src/core/log.c
 	$(CC) $(TEST_CFLAGS) -Isrc -Isrc/include $^ $(TEST_LIBS) -o $@
 
+tests/test_monitor_lifecycle: tests/test_monitor_lifecycle.c \
+    src/core/monitor.c src/compositor/workspace_models.c src/core/layer.c \
+    src/core/animation.c src/core/easing.c src/core/log.c
+	$(CC) $(TEST_CFLAGS) -Isrc -Isrc/include $^ $(TEST_LIBS) $(PKG_LIBS) -o $@
+
 # Run all tests
 test: $(ALL_TEST_TARGETS)
 	@echo "=== Running Full Test Suite ==="
@@ -415,12 +425,14 @@ test-scripts: $(TARGET)
 	fi
 
 # Run tests with valgrind for memory leak detection
-memcheck: $(ALL_TEST_TARGETS)
+memcheck:
 	@if ! command -v valgrind >/dev/null 2>&1; then \
 		echo "Error: valgrind is not installed."; \
 		echo "Install it with: sudo pacman -S valgrind (Arch) or sudo apt-get install valgrind (Debian/Ubuntu)"; \
 		exit 1; \
 	fi
+	@$(MAKE) clean-tests >/dev/null
+	@$(MAKE) CFLAGS='$(MEMCHECK_CFLAGS)' LDFLAGS='$(MEMCHECK_LDFLAGS)' $(ALL_TEST_TARGETS)
 	@echo "=== Running Tests with Valgrind Memory Check ==="
 	@failed=0; \
 	passed=0; \

--- a/scripts/test_hot_remove_virtual_output.sh
+++ b/scripts/test_hot_remove_virtual_output.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="${HYPRLAX_BIN:-$ROOT/hyprlax}"
+IMAGE="${HYPRLAX_SMOKE_IMAGE:-$ROOT/examples/space/bkgd_0.png}"
+SUFFIX="${HYPRLAX_SOCKET_SUFFIX:-hotremove-$$}"
+LOG="${HYPRLAX_SMOKE_LOG:-/tmp/hyprlax-hotremove-$SUFFIX.log}"
+WORKSPACE_EVENT="${HYPRLAX_SMOKE_WORKSPACE_EVENT:-1}"
+
+created_output=""
+daemon_pid=""
+original_workspace=""
+restored_workspace=0
+
+die() {
+    echo "FAIL: $*" >&2
+    if [ -f "$LOG" ]; then
+        echo "--- daemon log: $LOG ---" >&2
+        tail -n 120 "$LOG" >&2 || true
+    fi
+    exit 1
+}
+
+cleanup() {
+    set +e
+    if [ -n "$created_output" ]; then
+        hyprctl output remove "$created_output" >/dev/null 2>&1
+    fi
+    if [ -n "$daemon_pid" ] && kill -0 "$daemon_pid" >/dev/null 2>&1; then
+        kill "$daemon_pid" >/dev/null 2>&1
+        wait "$daemon_pid" >/dev/null 2>&1
+    fi
+    if [ "$restored_workspace" -eq 0 ] && [ -n "$original_workspace" ]; then
+        hyprctl dispatch workspace "$original_workspace" >/dev/null 2>&1
+    fi
+}
+trap cleanup EXIT
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || die "$1 is required"
+}
+
+need hyprctl
+need jq
+
+[ -x "$BIN" ] || die "hyprlax binary not executable: $BIN"
+[ -r "$IMAGE" ] || die "smoke image not readable: $IMAGE"
+
+mapfile -t before_outputs < <(hyprctl monitors -j | jq -r '.[].name' | sort)
+original_workspace="$(hyprctl activeworkspace -j | jq -r '.id')"
+
+hyprctl output create headless >/dev/null
+
+for _ in $(seq 1 50); do
+    mapfile -t after_outputs < <(hyprctl monitors -j | jq -r '.[].name' | sort)
+    created_output="$(
+        comm -13 \
+            <(printf '%s\n' "${before_outputs[@]}") \
+            <(printf '%s\n' "${after_outputs[@]}") | head -n 1
+    )"
+    [ -n "$created_output" ] && break
+    sleep 0.1
+done
+
+[ -n "$created_output" ] || die "failed to detect created virtual output"
+echo "Created virtual output: $created_output"
+
+HYPRLAX_SOCKET_SUFFIX="$SUFFIX" "$BIN" \
+    --fps 30 \
+    "$IMAGE" \
+    >"$LOG" 2>&1 &
+daemon_pid=$!
+
+ctl_status() {
+    HYPRLAX_SOCKET_SUFFIX="$SUFFIX" "$BIN" ctl status 2>&1
+}
+
+wait_for_ctl() {
+    local output
+    for _ in $(seq 1 80); do
+        if output="$(ctl_status)"; then
+            printf '%s\n' "$output"
+            return 0
+        fi
+        if ! kill -0 "$daemon_pid" >/dev/null 2>&1; then
+            wait "$daemon_pid" || true
+            die "test daemon exited before IPC became ready"
+        fi
+        sleep 0.1
+    done
+    die "test daemon IPC did not become ready"
+}
+
+status_before="$(wait_for_ctl)"
+printf '%s\n' "$status_before" | grep -q 'hyprlax running' || die "unexpected status before removal"
+printf '%s\n' "$status_before" | grep -q 'Monitors: 2' || die "test daemon did not see the virtual output"
+
+hyprctl output remove "$created_output" >/dev/null
+removed_output="$created_output"
+created_output=""
+
+for _ in $(seq 1 50); do
+    if ! hyprctl monitors -j | jq -e --arg name "$removed_output" 'map(.name) | index($name)' >/dev/null; then
+        break
+    fi
+    sleep 0.1
+done
+
+if hyprctl monitors -j | jq -e --arg name "$removed_output" 'map(.name) | index($name)' >/dev/null; then
+    die "virtual output still present after removal: $removed_output"
+fi
+
+status_after_remove="$(wait_for_ctl)"
+printf '%s\n' "$status_after_remove" | grep -q 'hyprlax running' || die "IPC stopped responding after output removal"
+printf '%s\n' "$status_after_remove" | grep -q 'Monitors: 1' || die "test daemon did not drop the removed output"
+
+if [ "$WORKSPACE_EVENT" = "1" ]; then
+    target_workspace=$((original_workspace == 1 ? 2 : original_workspace - 1))
+    hyprctl dispatch workspace "$target_workspace" >/dev/null
+    sleep 0.2
+    status_after_workspace="$(wait_for_ctl)"
+    printf '%s\n' "$status_after_workspace" | grep -q 'hyprlax running' || die "IPC stopped after workspace event"
+    hyprctl dispatch workspace "$original_workspace" >/dev/null
+    restored_workspace=1
+fi
+
+kill "$daemon_pid" >/dev/null 2>&1
+wait "$daemon_pid" >/dev/null 2>&1 || true
+daemon_pid=""
+
+echo "PASS: removed $removed_output; IPC stayed responsive; log: $LOG"

--- a/src/core/monitor.c
+++ b/src/core/monitor.c
@@ -206,6 +206,17 @@ void monitor_list_remove(monitor_list_t *list, monitor_instance_t *monitor) {
     }
 }
 
+bool monitor_list_remove_by_output(monitor_list_t *list, struct wl_output *output) {
+    monitor_instance_t *monitor = monitor_list_find_by_output(list, output);
+    if (!monitor) {
+        return false;
+    }
+
+    monitor_list_remove(list, monitor);
+    monitor_instance_destroy(monitor);
+    return true;
+}
+
 /* Find monitor by name */
 monitor_instance_t* monitor_list_find_by_name(monitor_list_t *list, const char *name) {
     if (!list || !name) return NULL;

--- a/src/core/monitor.h
+++ b/src/core/monitor.h
@@ -52,6 +52,7 @@ typedef struct monitor_instance {
     struct wl_output *wl_output;
     struct wl_surface *wl_surface;
     struct zwlr_layer_surface_v1 *layer_surface;
+    bool configured;                    /* Layer surface has received configure */
     void *wl_egl_window;              /* EGL window for this surface */
     void *wp_viewport;                /* wp_viewport for logical surface sizing (fractional scale) */
     void *wp_fractional_scale;        /* wp_fractional_scale_v1 for this surface */
@@ -117,6 +118,7 @@ void monitor_instance_destroy(monitor_instance_t *monitor);
 /* List operations */
 void monitor_list_add(monitor_list_t *list, monitor_instance_t *monitor);
 void monitor_list_remove(monitor_list_t *list, monitor_instance_t *monitor);
+bool monitor_list_remove_by_output(monitor_list_t *list, struct wl_output *output);
 monitor_instance_t* monitor_list_find_by_name(monitor_list_t *list, const char *name);
 monitor_instance_t* monitor_list_find_by_output(monitor_list_t *list, struct wl_output *output);
 monitor_instance_t* monitor_list_find_by_id(monitor_list_t *list, uint32_t id);

--- a/src/core/render_core.c
+++ b/src/core/render_core.c
@@ -77,6 +77,10 @@ static void hyprlax_render_monitor(hyprlax_context_t *ctx, monitor_instance_t *m
         LOG_WARN("Monitor %s has no EGL surface", monitor->name);
         return;
     }
+    if (!monitor->configured) {
+        LOG_TRACE("Skipping unconfigured monitor %s", monitor->name);
+        return;
+    }
 
     /* Frame-callback pacing: skip draw/present if a frame callback is pending
      * AND we haven't waited too long.  Some compositors (Hyprland) may not

--- a/src/core/resource_monitor.c
+++ b/src/core/resource_monitor.c
@@ -77,6 +77,33 @@ void resource_monitor_destroy(resource_monitor_t *monitor) {
     free(monitor);
 }
 
+void resource_monitor_reset_baseline(resource_monitor_t *monitor) {
+    if (!monitor || !monitor->enabled) return;
+
+    monitor->fd_count_start = resource_monitor_get_fd_count();
+    monitor->fd_count_current = monitor->fd_count_start;
+    monitor->fd_count_max = monitor->fd_count_start;
+
+    monitor->memory_rss_start_kb = resource_monitor_get_memory_rss_kb();
+    monitor->memory_rss_current_kb = monitor->memory_rss_start_kb;
+    monitor->memory_rss_max_kb = monitor->memory_rss_start_kb;
+
+    monitor->memory_vms_start_kb = resource_monitor_get_memory_vms_kb();
+    monitor->memory_vms_current_kb = monitor->memory_vms_start_kb;
+
+    monitor->check_count = 0;
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+        monitor->last_check_time = ts.tv_sec + ts.tv_nsec / 1000000000.0;
+    } else {
+        monitor->last_check_time = 0.0;
+    }
+    LOG_INFO("Resource monitor baseline reset - FDs: %d, RSS: %zu KB, VMS: %zu KB",
+             monitor->fd_count_start,
+             monitor->memory_rss_start_kb,
+             monitor->memory_vms_start_kb);
+}
+
 int resource_monitor_get_fd_count(void) {
     DIR *dir = opendir("/proc/self/fd");
     if (!dir) return -1;

--- a/src/hyprlax_main.c
+++ b/src/hyprlax_main.c
@@ -1188,6 +1188,9 @@ int hyprlax_init(hyprlax_context_t *ctx, int argc, char **argv) {
     if (ctx->monitors) {
         monitor_instance_t *monitor = ctx->monitors->head;
         while (monitor) {
+            LOG_DEBUG("[INIT] Monitor %s surface state: wl_egl_window=%p egl_surface=%p configured=%d",
+                      monitor->name, monitor->wl_egl_window,
+                      (void*)monitor->egl_surface, monitor->configured ? 1 : 0);
             if (monitor->wl_egl_window && !monitor->egl_surface) {
                 monitor->egl_surface = gles2_create_monitor_surface(monitor->wl_egl_window);
                 if (monitor->egl_surface) {
@@ -1220,6 +1223,10 @@ int hyprlax_init(hyprlax_context_t *ctx, int argc, char **argv) {
 
     /* 8. Setup epoll/timerfd event loop */
     hyprlax_setup_epoll(ctx);
+
+    if (ctx->resource_monitor) {
+        resource_monitor_reset_baseline(ctx->resource_monitor);
+    }
 
     ctx->state = APP_STATE_RUNNING;
     ctx->running = true;
@@ -1536,6 +1543,13 @@ void hyprlax_shutdown(hyprlax_context_t *ctx) {
         ctx->ipc_ctx = NULL;
     }
 
+    /* Monitors must be destroyed before renderer/platform teardown because
+     * each monitor owns both an EGLSurface and Wayland objects. */
+    if (ctx->monitors) {
+        monitor_list_destroy(ctx->monitors);
+        ctx->monitors = NULL;
+    }
+
     /* Renderer */
     if (ctx->renderer) {
         renderer_destroy(ctx->renderer);
@@ -1552,12 +1566,6 @@ void hyprlax_shutdown(hyprlax_context_t *ctx) {
     if (ctx->platform) {
         platform_destroy(ctx->platform);
         ctx->platform = NULL;
-    }
-
-    /* Monitors */
-    if (ctx->monitors) {
-        monitor_list_destroy(ctx->monitors);
-        ctx->monitors = NULL;
     }
 
     if (ctx->config.debug) {

--- a/src/include/resource_monitor.h
+++ b/src/include/resource_monitor.h
@@ -53,6 +53,9 @@ resource_monitor_t* resource_monitor_create(double check_interval);
 /* Destroy resource monitor */
 void resource_monitor_destroy(resource_monitor_t *monitor);
 
+/* Reset baseline to the current resource footprint after expected allocations */
+void resource_monitor_reset_baseline(resource_monitor_t *monitor);
+
 /* Perform a health check (called periodically) */
 void resource_monitor_check(resource_monitor_t *monitor);
 

--- a/src/platform/wayland.c
+++ b/src/platform/wayland.c
@@ -139,6 +139,87 @@ static const struct wl_callback_listener frame_listener = {
 /* Forward for monitor surface creation */
 int wayland_create_monitor_surface(monitor_instance_t *monitor);
 
+static void wayland_clear_pointer_for_monitor(wayland_data_t *wl_data,
+                                              const monitor_instance_t *monitor) {
+    if (!wl_data || !monitor) return;
+    if (wl_data->pointer_surface == monitor->wl_surface) {
+        wl_data->pointer_surface = NULL;
+        wl_data->pointer_valid = false;
+    }
+}
+
+static struct wl_output *wayland_first_output_except(wayland_data_t *wl_data,
+                                                     struct wl_output *removed_output) {
+    if (!wl_data) return NULL;
+
+    for (output_info_t *info = wl_data->outputs; info; info = info->next) {
+        if (info->output && info->output != removed_output) {
+            return info->output;
+        }
+    }
+
+    return NULL;
+}
+
+static bool wayland_remove_monitor_for_output(wayland_data_t *wl_data,
+                                              struct wl_output *output) {
+    if (!wl_data || !wl_data->ctx || !wl_data->ctx->monitors || !output) {
+        return false;
+    }
+
+    monitor_instance_t *monitor = monitor_list_find_by_output(wl_data->ctx->monitors, output);
+    if (!monitor) {
+        return false;
+    }
+
+    char name[sizeof(monitor->name)];
+    snprintf(name, sizeof(name), "%s", monitor->name);
+    wayland_clear_pointer_for_monitor(wl_data, monitor);
+    if (wl_data->output == output) {
+        wl_data->output = wayland_first_output_except(wl_data, output);
+    }
+
+    bool removed = monitor_list_remove_by_output(wl_data->ctx->monitors, output);
+    if (removed) {
+        input_manager_reset_cache(&wl_data->ctx->input);
+        LOG_INFO("Removed Wayland monitor for output %s", name);
+    }
+    return removed;
+}
+
+static void wayland_destroy_all_monitors(wayland_data_t *wl_data) {
+    if (!wl_data || !wl_data->ctx || !wl_data->ctx->monitors) {
+        return;
+    }
+
+    monitor_instance_t *monitor = wl_data->ctx->monitors->head;
+    while (monitor) {
+        monitor_instance_t *next = monitor->next;
+        wayland_clear_pointer_for_monitor(wl_data, monitor);
+        monitor_list_remove(wl_data->ctx->monitors, monitor);
+        monitor_instance_destroy(monitor);
+        monitor = next;
+    }
+}
+
+static void wayland_destroy_output_list(wayland_data_t *wl_data) {
+    if (!wl_data) return;
+
+    output_info_t *info = wl_data->outputs;
+    while (info) {
+        output_info_t *next = info->next;
+        if (info->output) {
+            wl_output_destroy(info->output);
+        }
+        free(info);
+        info = next;
+    }
+
+    wl_data->outputs = NULL;
+    wl_data->output = NULL;
+    wl_data->output_count = 0;
+}
+
 /* Store context for monitor detection - set by platform init */
 void wayland_set_context(hyprlax_context_t *ctx) {
     if (!g_wayland_data) return;
@@ -279,6 +360,10 @@ static void registry_global_remove(void *data, struct wl_registry *registry,
             output_info_t *to_free = *curr;
             *curr = to_free->next;  /* Unlink from list */
 
+            if (to_free->output) {
+                wayland_remove_monitor_for_output(wl_data, to_free->output);
+            }
+
             /* Clean up Wayland objects */
             if (to_free->output) {
                 wl_output_destroy(to_free->output);
@@ -375,6 +460,46 @@ static const struct zwlr_layer_surface_v1_listener layer_surface_listener = {
     .closed = layer_surface_closed,
 };
 
+static void monitor_layer_surface_configure(void *data,
+                                            struct zwlr_layer_surface_v1 *layer_surface,
+                                            uint32_t serial,
+                                            uint32_t width, uint32_t height) {
+    monitor_instance_t *monitor = (monitor_instance_t *)data;
+
+    if (monitor) {
+        LOG_DEBUG("Monitor %s layer surface configure: %ux%u",
+                  monitor->name, width, height);
+        monitor->configured = true;
+        if (monitor->width <= 0 && monitor->height <= 0 && width > 0 && height > 0) {
+            monitor_update_geometry(monitor, (int)width, (int)height,
+                                    monitor->scale, monitor->refresh_rate);
+        }
+    }
+
+    zwlr_layer_surface_v1_ack_configure(layer_surface, serial);
+}
+
+static void monitor_layer_surface_closed(void *data,
+                                         struct zwlr_layer_surface_v1 *layer_surface) {
+    monitor_instance_t *monitor = (monitor_instance_t *)data;
+    (void)layer_surface;
+
+    if (!monitor || !g_wayland_data || !g_wayland_data->ctx ||
+        !g_wayland_data->ctx->monitors) {
+        return;
+    }
+
+    struct wl_output *output = monitor->wl_output;
+    if (output) {
+        wayland_remove_monitor_for_output(g_wayland_data, output);
+    }
+}
+
+static const struct zwlr_layer_surface_v1_listener monitor_layer_surface_listener = {
+    .configure = monitor_layer_surface_configure,
+    .closed = monitor_layer_surface_closed,
+};
+
 static const struct wl_registry_listener registry_listener = {
     .global = registry_global,
     .global_remove = registry_global_remove,
@@ -453,25 +578,7 @@ static int wayland_connect(const char *display_name) {
 static void wayland_disconnect(void) {
     if (!g_wayland_data) return;
 
-    /* Destroy per-monitor Wayland resources if context is present */
-    if (g_wayland_data->ctx && g_wayland_data->ctx->monitors) {
-        monitor_instance_t *mon = g_wayland_data->ctx->monitors->head;
-        while (mon) {
-            if (mon->wl_egl_window) {
-                wl_egl_window_destroy(mon->wl_egl_window);
-                mon->wl_egl_window = NULL;
-            }
-            if (mon->layer_surface) {
-                zwlr_layer_surface_v1_destroy(mon->layer_surface);
-                mon->layer_surface = NULL;
-            }
-            if (mon->wl_surface) {
-                wl_surface_destroy(mon->wl_surface);
-                mon->wl_surface = NULL;
-            }
-            mon = mon->next;
-        }
-    }
+    wayland_destroy_all_monitors(g_wayland_data);
 
     if (g_wayland_data->egl_window) {
         wl_egl_window_destroy(g_wayland_data->egl_window);
@@ -487,6 +594,28 @@ static void wayland_disconnect(void) {
         wl_surface_destroy(g_wayland_data->surface);
         g_wayland_data->surface = NULL;
     }
+
+    if (g_wayland_data->pointer) {
+        wl_pointer_destroy(g_wayland_data->pointer);
+        g_wayland_data->pointer = NULL;
+    }
+
+    if (g_wayland_data->seat) {
+        wl_seat_destroy(g_wayland_data->seat);
+        g_wayland_data->seat = NULL;
+    }
+
+    if (g_wayland_data->fractional_scale_manager) {
+        wp_fractional_scale_manager_v1_destroy(g_wayland_data->fractional_scale_manager);
+        g_wayland_data->fractional_scale_manager = NULL;
+    }
+
+    if (g_wayland_data->viewporter) {
+        wp_viewporter_destroy(g_wayland_data->viewporter);
+        g_wayland_data->viewporter = NULL;
+    }
+
+    wayland_destroy_output_list(g_wayland_data);
 
     if (g_wayland_data->layer_shell) {
         zwlr_layer_shell_v1_destroy(g_wayland_data->layer_shell);
@@ -755,8 +884,8 @@ int wayland_create_monitor_surface(monitor_instance_t *monitor) {
 
             /* Add listener for this monitor's layer surface */
             zwlr_layer_surface_v1_add_listener(monitor->layer_surface,
-                                              &layer_surface_listener,
-                                              g_wayland_data);
+                                              &monitor_layer_surface_listener,
+                                              monitor);
 
             /* Commit to get configure event */
             wl_surface_commit(monitor->wl_surface);
@@ -810,6 +939,8 @@ int wayland_create_monitor_surface(monitor_instance_t *monitor) {
             monitor->wl_surface = NULL;
             return HYPRLAX_ERROR_NO_MEMORY;
         }
+        LOG_DEBUG("Created EGL window for monitor %s: %p",
+                  monitor->name, monitor->wl_egl_window);
 
         /* Create EGL surface for this monitor if we have a renderer context */
         if (g_wayland_data->ctx && g_wayland_data->ctx->renderer) {

--- a/src/renderer/gles2.c
+++ b/src/renderer/gles2.c
@@ -59,6 +59,12 @@ typedef struct {
 static gles2_renderer_data_t *g_gles2_data = NULL;
 static void gles2_create_blur_target(int width, int height);
 
+static void gles2_upload_quad_vertices(const GLfloat *vertices, size_t size) {
+    if (!g_gles2_data || !vertices || size == 0) return;
+    glBindBuffer(GL_ARRAY_BUFFER, g_gles2_data->vbo);
+    glBufferSubData(GL_ARRAY_BUFFER, 0, size, vertices);
+}
+
 /* Quad vertices for layer rendering */
 static const GLfloat quad_vertices[] = {
     /* Position    Texture Coords */
@@ -256,6 +262,13 @@ static void gles2_destroy(void) {
         shader_destroy_program(g_gles2_data->blur_sep_shader);
     }
 
+    if (g_gles2_data->blur_tex) {
+        glDeleteTextures(1, &g_gles2_data->blur_tex);
+    }
+    if (g_gles2_data->blur_fbo) {
+        glDeleteFramebuffers(1, &g_gles2_data->blur_fbo);
+    }
+
     if (g_gles2_data->vbo) {
         glDeleteBuffers(1, &g_gles2_data->vbo);
     }
@@ -274,13 +287,6 @@ static void gles2_destroy(void) {
 
     if (g_gles2_data->egl_display != EGL_NO_DISPLAY) {
         eglTerminate(g_gles2_data->egl_display);
-    }
-
-    if (g_gles2_data->blur_tex) {
-        glDeleteTextures(1, &g_gles2_data->blur_tex);
-    }
-    if (g_gles2_data->blur_fbo) {
-        glDeleteFramebuffers(1, &g_gles2_data->blur_fbo);
     }
 
     free(g_gles2_data);
@@ -361,9 +367,7 @@ static void gles2_fade_frame(float r, float g, float b, float a) {
          1.0f,  1.0f,  1.0f, 0.0f
     };
 
-    GLuint vbo = 0; glGenBuffers(1, &vbo);
-    glBindBuffer(GL_ARRAY_BUFFER, vbo);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+    gles2_upload_quad_vertices(vertices, sizeof(vertices));
 
     GLint pos_attrib = shader_get_attrib_location(g_gles2_data->fill_shader, "a_position");
     GLint tex_attrib = shader_get_attrib_location(g_gles2_data->fill_shader, "a_texcoord");
@@ -381,7 +385,6 @@ static void gles2_fade_frame(float r, float g, float b, float a) {
 
     if (pos_attrib >= 0) glDisableVertexAttribArray(pos_attrib);
     if (tex_attrib >= 0) glDisableVertexAttribArray(tex_attrib);
-    glDeleteBuffers(1, &vbo);
 }
 
 /* Helpers for extended draw */
@@ -834,18 +837,7 @@ static void gles2_draw_layer_internal(const texture_t *texture, float x, float y
         glViewport(0, 0, g_gles2_data->blur_w, g_gles2_data->blur_h);
         gles2_bind_texture(texture, 0);
 
-        /* Setup vertex data */
-        const char *persist_vbo = getenv("HYPRLAX_PERSISTENT_VBO");
-        GLuint vbo = 0;
-        if (persist_vbo && *persist_vbo && g_gles2_data->vbo) {
-            glBindBuffer(GL_ARRAY_BUFFER, g_gles2_data->vbo);
-            /* Use precomputed vertices (pos+texcoords) */
-            glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(vertices), vertices);
-        } else {
-            glGenBuffers(1, &vbo);
-            glBindBuffer(GL_ARRAY_BUFFER, vbo);
-            glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
-        }
+        gles2_upload_quad_vertices(vertices, sizeof(vertices));
 
         GLint pos_attrib = shader_get_attrib_location(shader, "a_position");
         GLint tex_attrib = shader_get_attrib_location(shader, "a_texcoord");
@@ -880,26 +872,13 @@ static void gles2_draw_layer_internal(const texture_t *texture, float x, float y
         texture_t tmp = { .id = g_gles2_data->blur_tex };
         gles2_bind_texture(&tmp, 0);
         /* Rebind vertex data and attrib pointers to be explicit for second pass */
-        if (persist_vbo && *persist_vbo && g_gles2_data->vbo) {
-            glBindBuffer(GL_ARRAY_BUFFER, g_gles2_data->vbo);
-            /* For separable path, sample the FBO texture; flip V for FBO sampling */
-            GLfloat v2[] = {
-                vertices[0], vertices[1], vertices[2], 1.0f - vertices[3],
-                vertices[4], vertices[5], vertices[6], 1.0f - vertices[7],
-                vertices[8], vertices[9], vertices[10],1.0f - vertices[11],
-                vertices[12],vertices[13],vertices[14],1.0f - vertices[15]
-            };
-            glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(v2), v2);
-        } else {
-            glBindBuffer(GL_ARRAY_BUFFER, vbo);
-            GLfloat v2[] = {
-                vertices[0], vertices[1], vertices[2], 1.0f - vertices[3],
-                vertices[4], vertices[5], vertices[6], 1.0f - vertices[7],
-                vertices[8], vertices[9], vertices[10],1.0f - vertices[11],
-                vertices[12],vertices[13],vertices[14],1.0f - vertices[15]
-            };
-            glBufferData(GL_ARRAY_BUFFER, sizeof(v2), v2, GL_STATIC_DRAW);
-        }
+        GLfloat v2[] = {
+            vertices[0], vertices[1], vertices[2], 1.0f - vertices[3],
+            vertices[4], vertices[5], vertices[6], 1.0f - vertices[7],
+            vertices[8], vertices[9], vertices[10],1.0f - vertices[11],
+            vertices[12],vertices[13],vertices[14],1.0f - vertices[15]
+        };
+        gles2_upload_quad_vertices(v2, sizeof(v2));
         if (pos_attrib >= 0) {
             glEnableVertexAttribArray(pos_attrib);
             glVertexAttribPointer(pos_attrib, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(GLfloat), (void*)0);
@@ -912,10 +891,6 @@ static void gles2_draw_layer_internal(const texture_t *texture, float x, float y
 
         if (pos_attrib >= 0) glDisableVertexAttribArray(pos_attrib);
         if (tex_attrib >= 0) glDisableVertexAttribArray(tex_attrib);
-        if (!(persist_vbo && *persist_vbo)) {
-            glDeleteBuffers(1, &vbo);
-        }
-
         goto done;
     }
 
@@ -932,17 +907,7 @@ static void gles2_draw_layer_internal(const texture_t *texture, float x, float y
         }
     }
 
-    /* Setup vertex data */
-    const char *persist_vbo = getenv("HYPRLAX_PERSISTENT_VBO");
-    GLuint vbo = 0;
-    if (persist_vbo && *persist_vbo && g_gles2_data->vbo) {
-        glBindBuffer(GL_ARRAY_BUFFER, g_gles2_data->vbo);
-        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(vertices), vertices);
-    } else {
-        glGenBuffers(1, &vbo);
-        glBindBuffer(GL_ARRAY_BUFFER, vbo);
-        glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
-    }
+    gles2_upload_quad_vertices(vertices, sizeof(vertices));
 
     GLint pos_attrib = shader_get_attrib_location(shader, "a_position");
     GLint tex_attrib = shader_get_attrib_location(shader, "a_texcoord");
@@ -975,9 +940,6 @@ static void gles2_draw_layer_internal(const texture_t *texture, float x, float y
     /* Cleanup */
     if (pos_attrib >= 0) glDisableVertexAttribArray(pos_attrib);
     if (tex_attrib >= 0) glDisableVertexAttribArray(tex_attrib);
-    if (!(persist_vbo && *persist_vbo)) {
-        glDeleteBuffers(1, &vbo);
-    }
 
     if (draw_count < 5 && getenv("HYPRLAX_DEBUG")) {
         fprintf(stderr, "[DEBUG] gles2_draw_layer %d: Complete\n", draw_count);
@@ -1068,6 +1030,9 @@ void gles2_destroy_monitor_surface(EGLSurface surface) {
         return;
     }
 
+    if (g_gles2_data->current_surface == surface) {
+        g_gles2_data->current_surface = EGL_NO_SURFACE;
+    }
     eglDestroySurface(g_gles2_data->egl_display, surface);
 }
 

--- a/src/vendor/gifdec.c
+++ b/src/vendor/gifdec.c
@@ -48,6 +48,9 @@ gd_open_gif(const char *fname)
     int gct_sz;
     gd_GIF *gif;
 
+    if (!fname)
+        return NULL;
+
     fd = open(fname, O_RDONLY);
     if (fd == -1)
         return NULL;

--- a/tests/stubs_gfx.c
+++ b/tests/stubs_gfx.c
@@ -8,3 +8,11 @@ unsigned int load_texture(const char *path, int *width, int *height) {
     return 1; /* non-zero fake texture id */
 }
 
+void gles2_destroy_monitor_surface(void *surface) {
+    (void)surface;
+}
+
+typedef struct gd_GIF gd_GIF;
+void gd_close_gif(gd_GIF *gif) {
+    (void)gif;
+}

--- a/tests/test_monitor_lifecycle.c
+++ b/tests/test_monitor_lifecycle.c
@@ -1,0 +1,122 @@
+/*
+ * test_monitor_lifecycle.c - Regression tests for monitor removal cleanup
+ */
+
+#include <check.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "../src/core/monitor.h"
+#include "../src/include/log.h"
+
+void gles2_destroy_monitor_surface(EGLSurface surface) {
+    (void)surface;
+}
+
+static struct wl_output *fake_output(uintptr_t id) {
+    return (struct wl_output *)id;
+}
+
+START_TEST(test_remove_by_output_destroys_secondary_monitor)
+{
+    monitor_list_t *list = monitor_list_create();
+    ck_assert_ptr_nonnull(list);
+
+    monitor_instance_t *primary = monitor_instance_create("eDP-1");
+    monitor_instance_t *secondary = monitor_instance_create("DP-1");
+    ck_assert_ptr_nonnull(primary);
+    ck_assert_ptr_nonnull(secondary);
+
+    primary->wl_output = fake_output(0x1000);
+    secondary->wl_output = fake_output(0x2000);
+
+    monitor_list_add(list, primary);
+    monitor_list_add(list, secondary);
+    ck_assert_int_eq(list->count, 2);
+    ck_assert_ptr_eq(list->primary, primary);
+
+    ck_assert(monitor_list_remove_by_output(list, secondary->wl_output));
+
+    ck_assert_int_eq(list->count, 1);
+    ck_assert_ptr_eq(list->head, primary);
+    ck_assert_ptr_eq(list->primary, primary);
+    ck_assert_ptr_null(primary->next);
+    ck_assert_ptr_null(monitor_list_find_by_output(list, fake_output(0x2000)));
+
+    monitor_list_destroy(list);
+}
+END_TEST
+
+START_TEST(test_remove_by_output_promotes_primary)
+{
+    monitor_list_t *list = monitor_list_create();
+    ck_assert_ptr_nonnull(list);
+
+    monitor_instance_t *primary = monitor_instance_create("eDP-1");
+    monitor_instance_t *secondary = monitor_instance_create("DP-1");
+    ck_assert_ptr_nonnull(primary);
+    ck_assert_ptr_nonnull(secondary);
+
+    primary->wl_output = fake_output(0x3000);
+    secondary->wl_output = fake_output(0x4000);
+
+    monitor_list_add(list, primary);
+    monitor_list_add(list, secondary);
+
+    ck_assert(monitor_list_remove_by_output(list, primary->wl_output));
+
+    ck_assert_int_eq(list->count, 1);
+    ck_assert_ptr_eq(list->head, secondary);
+    ck_assert_ptr_eq(list->primary, secondary);
+    ck_assert(secondary->is_primary);
+
+    monitor_list_destroy(list);
+}
+END_TEST
+
+START_TEST(test_remove_by_output_missing_is_noop)
+{
+    monitor_list_t *list = monitor_list_create();
+    ck_assert_ptr_nonnull(list);
+
+    monitor_instance_t *monitor = monitor_instance_create("eDP-1");
+    ck_assert_ptr_nonnull(monitor);
+    monitor->wl_output = fake_output(0x5000);
+    monitor_list_add(list, monitor);
+
+    ck_assert(!monitor_list_remove_by_output(list, fake_output(0x6000)));
+
+    ck_assert_int_eq(list->count, 1);
+    ck_assert_ptr_eq(list->head, monitor);
+    ck_assert_ptr_eq(list->primary, monitor);
+
+    monitor_list_destroy(list);
+}
+END_TEST
+
+Suite *monitor_lifecycle_suite(void)
+{
+    Suite *s = suite_create("MonitorLifecycle");
+    TCase *tc_core = tcase_create("Core");
+
+    tcase_add_test(tc_core, test_remove_by_output_destroys_secondary_monitor);
+    tcase_add_test(tc_core, test_remove_by_output_promotes_primary);
+    tcase_add_test(tc_core, test_remove_by_output_missing_is_noop);
+    suite_add_tcase(s, tc_core);
+
+    return s;
+}
+
+int main(void)
+{
+    log_init(false, NULL);
+
+    Suite *s = monitor_lifecycle_suite();
+    SRunner *sr = srunner_create(s);
+    srunner_run_all(sr, CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+
+    log_cleanup();
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/test_renderer_resource_churn.sh
+++ b/tests/test_renderer_resource_churn.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+FILE="src/renderer/gles2.c"
+
+awk '
+    /^static void gles2_fade_frame/ {
+        fn = "gles2_fade_frame";
+    }
+    /^static void gles2_draw_layer_internal/ {
+        fn = "gles2_draw_layer_internal";
+    }
+    /^static void compute_fit_params/ || /^static void gles2_draw_layer\(/ {
+        fn = "";
+    }
+    fn && /glGenBuffers/ {
+        printf("%s:%d: glGenBuffers in hot render path (%s)\n", FILENAME, FNR, fn);
+        bad = 1;
+    }
+    END {
+        exit bad;
+    }
+' "$FILE"

--- a/tests/test_resource_monitor.c
+++ b/tests/test_resource_monitor.c
@@ -115,6 +115,31 @@ START_TEST(test_resource_monitor_growth_tracking)
 }
 END_TEST
 
+/* Test: Reset baseline after expected startup resource allocation */
+START_TEST(test_resource_monitor_reset_baseline)
+{
+    resource_monitor_t *monitor = resource_monitor_create(10.0);
+    ck_assert_ptr_nonnull(monitor);
+
+    int fd = open("/dev/null", O_RDONLY);
+    ck_assert_int_ge(fd, 0);
+
+    int reset_fds = resource_monitor_get_fd_count();
+    resource_monitor_reset_baseline(monitor);
+    ck_assert_int_eq(monitor->fd_count_start, reset_fds);
+    ck_assert_int_eq(monitor->fd_count_current, reset_fds);
+    ck_assert_int_eq(monitor->fd_count_max, reset_fds);
+    ck_assert_uint_eq(monitor->check_count, 0);
+
+    resource_monitor_check(monitor);
+    ck_assert_int_eq(monitor->fd_count_current, reset_fds);
+    ck_assert_int_eq(monitor->fd_count_max, reset_fds);
+
+    close(fd);
+    resource_monitor_destroy(monitor);
+}
+END_TEST
+
 /* Test: Environment variable configuration */
 START_TEST(test_resource_monitor_env_config)
 {
@@ -172,6 +197,7 @@ Suite *resource_monitor_suite(void)
     tcase_add_test(tc_core, test_resource_monitor_memory);
     tcase_add_test(tc_core, test_resource_monitor_periodic_check);
     tcase_add_test(tc_core, test_resource_monitor_growth_tracking);
+    tcase_add_test(tc_core, test_resource_monitor_reset_baseline);
     tcase_add_test(tc_core, test_resource_monitor_env_config);
     tcase_add_test(tc_core, test_resource_monitor_disabled);
     suite_add_tcase(s, tc_core);

--- a/tests/test_runtime_properties.c
+++ b/tests/test_runtime_properties.c
@@ -41,7 +41,7 @@ START_TEST(test_runtime_set_get)
     ck_assert_int_eq(hyprlax_runtime_get_property(ctx, "parallax.sources.cursor.weight", buf, sizeof(buf)), 0);
     ck_assert_str_eq(buf, "0.420");
 
-    // Do not call hyprlax_destroy here to avoid pulling more deps
+    hyprlax_destroy(ctx);
 }
 END_TEST
 


### PR DESCRIPTION
## Summary
- Fix Wayland monitor cleanup during output hot-remove.
- Remove render-loop VBO churn and reset resource baselines after startup.
- Add regression tests and a Hyprland virtual-output smoke test.

## Verification
- make test
- make test-scripts
- scripts/test_hot_remove_virtual_output.sh
- make lint
- make memcheck

Fixes #89
Fixes #90