### PR TITLE
feat: project Dynamic Pixel City sun from local sky geometry

### DIFF
--- a/examples/pixel-city-dynamic/README.md
+++ b/examples/pixel-city-dynamic/README.md
@@ -94,18 +94,51 @@ python3 "$SCENE" --once --hyprlax-bin "$HYPRLAX" \
 # Reproduce a live astronomical state at an explicit offset-aware instant.
 python3 "$SCENE" --once --hyprlax-bin "$HYPRLAX" \
   --at 2026-07-12T05:15:00+02:00
+
+# Face east instead of centering the view on the solar-noon bearing.
+python3 "$SCENE" --once --hyprlax-bin "$HYPRLAX" --view-azimuth 90
 ```
 
 `--dry-run` intentionally uses neutral 06:00/12:00/18:00 anchors and assumed preview IDs. It is
 for deterministic lighting/command inspection, not a provider forecast. `--status` uses the real
 daily cache/providers but does not open the Hyprlax socket.
 
+### Geographic sun projection
+
+During a normal solar day, the controller uses the provider's sunrise, solar-noon, and sunset
+timestamps plus their azimuths and the solar-noon altitude. It interpolates altitude with a sine
+rise before noon and a cosine descent after noon. Azimuth follows the shortest angular path, so
+an interval such as 350 degrees to 10 degrees crosses north at 0 degrees instead of sweeping
+through south.
+
+Those solar coordinates feed a 2D side projection in scene space. Horizontal position combines
+relative azimuth with the altitude-adjusted 0.34 scene radius; vertical position maps the sine of
+altitude from the 0.18 horizon toward the -0.24 zenith limit. All output remains within the
+existing `SceneState` bounds.
+
+`--view-azimuth DEGREES` sets the compass direction faced by the scene: 0 is north, 90 east, 180
+south, and 270 west. Values from 0 through 360 are accepted. When omitted, the controller uses
+the day's solar-noon azimuth, which horizontally centers the sun at solar noon.
+
+If any required timestamp, azimuth, or solar-noon altitude is missing, non-finite, out of range,
+or out of chronological order, the controller uses the legacy static trajectory. Visibility,
+opacity, inverse UV offsets, caching, IPC ownership, polar night, and midnight sun retain their
+existing behavior.
+
 ### Full-day tuning mode
 
 `--demo-day` resolves today's location and astronomy once, anchors its mock clock at local
 midnight, and advances through 24 wall-clock hours before exiting. The defaults produce one visual
 update per real second for 60 seconds. Each JSON line includes `simulated_at`, `progress`, `phase`,
-and the number of IPC commands applied.
+projected `sun_x`/`sun_y`, and the number of IPC commands applied.
+
+Example full-day geographic tuning pass for Budapest while facing southeast:
+
+```bash
+python3 "$SCENE" --demo-day --demo-seconds 60 --demo-step 1 \
+  --latitude 47.4979 --longitude 19.0402 --timezone Europe/Budapest \
+  --locality Budapest --view-azimuth 135 --hyprlax-bin "$HYPRLAX"
+```
 
 Only one controller should own the layers. When using the installed user services, pause the
 normal real-time controller around the demo:

--- a/examples/pixel-city-dynamic/dynamic_scene.py
+++ b/examples/pixel-city-dynamic/dynamic_scene.py
@@ -393,6 +393,16 @@ def _lerp(start: float, end: float, amount: float) -> float:
     return start + (end - start) * amount
 
 
+def _wrap_degrees(value: float) -> float:
+    """Wrap an angle to the signed interval [-180, 180)."""
+    return (value + 180.0) % 360.0 - 180.0
+
+
+def _shortest_angle_lerp(start: float, end: float, amount: float) -> float:
+    """Interpolate azimuth through the shortest turn and return 0..360 degrees."""
+    return (start + _wrap_degrees(end - start) * amount) % 360.0
+
+
 def _smoothstep(amount: float) -> float:
     bounded = _clamp(amount)
     return bounded * bounded * (3.0 - 2.0 * bounded)
@@ -490,22 +500,13 @@ def _lighting_at(
     return preset.name, 0.0, ambient, colorfulness, stars, city, looks
 
 
-def _sun_state(
-    now: datetime, astronomy: Astronomy
+def _legacy_sun_state(
+    local: datetime, astronomy: Astronomy
 ) -> Tuple[bool, float, float, float, float, float]:
-    zone = _zone(astronomy.timezone)
-    local = now.astimezone(zone)
-    if astronomy.sun_status == "polar_night":
-        return False, 0.0, -0.34, 0.18, 0.0, 0.0
-    if astronomy.sun_status == "midnight_sun":
-        midnight = datetime.combine(local.date(), time.min, zone)
-        progress = _clamp((local - midnight).total_seconds() / 86400.0)
-        elevation = 0.55 + 0.45 * math.sin(math.pi * progress) ** 2
-        x = 0.34 * math.sin(2.0 * math.pi * (progress - 0.25))
-        y = 0.05 - 0.25 * elevation
-        return True, progress, x, y, 1.0, elevation
+    """Return the original time-only arc used when geographic inputs are unusable."""
     sunrise = astronomy.sunrise or neutral_astronomy(astronomy.day, astronomy.timezone).sunrise
     sunset = astronomy.sunset or neutral_astronomy(astronomy.day, astronomy.timezone).sunset
+    zone = _zone(astronomy.timezone)
     assert sunrise is not None and sunset is not None
     sunrise = sunrise.astimezone(zone)
     sunset = sunset.astimezone(zone)
@@ -520,6 +521,102 @@ def _sun_state(
     horizon = _clamp(min(progress / 0.08, (1.0 - progress) / 0.08))
     visible = 0.0 <= raw <= 1.0
     return visible, progress, x, y, horizon if visible else 0.0, elevation
+
+
+def _solar_position_number(
+    value: Any, minimum: float, maximum: float
+) -> Optional[float]:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    number = float(value)
+    if not math.isfinite(number) or not minimum <= number <= maximum:
+        return None
+    return number
+
+
+def _geographic_sun_position(
+    local: datetime,
+    astronomy: Astronomy,
+    view_azimuth: Optional[float],
+) -> Optional[Tuple[float, float, float]]:
+    position = astronomy.solar_position
+    if not isinstance(position, Mapping):
+        return None
+    sunrise_azimuth = _solar_position_number(
+        position.get("sunrise_azimuth"), 0.0, 360.0
+    )
+    noon_azimuth = _solar_position_number(
+        position.get("solar_noon_azimuth"), 0.0, 360.0
+    )
+    sunset_azimuth = _solar_position_number(
+        position.get("sunset_azimuth"), 0.0, 360.0
+    )
+    noon_altitude = _solar_position_number(
+        position.get("solar_noon_altitude"), 0.0, 90.0
+    )
+    values = (sunrise_azimuth, noon_azimuth, sunset_azimuth, noon_altitude)
+    if any(value is None for value in values):
+        return None
+    if view_azimuth is not None:
+        view_azimuth = _solar_position_number(view_azimuth, 0.0, 360.0)
+        if view_azimuth is None:
+            return None
+    else:
+        view_azimuth = noon_azimuth
+
+    sunrise = astronomy.sunrise
+    solar_noon = astronomy.solar_noon
+    sunset = astronomy.sunset
+    if sunrise is None or solar_noon is None or sunset is None:
+        return None
+    zone = _zone(astronomy.timezone)
+    sunrise = sunrise.astimezone(zone)
+    solar_noon = solar_noon.astimezone(zone)
+    sunset = sunset.astimezone(zone)
+    if not sunrise < solar_noon < sunset:
+        return None
+
+    if local <= solar_noon:
+        span = (solar_noon - sunrise).total_seconds()
+        amount = _clamp((local - sunrise).total_seconds() / span)
+        altitude = noon_altitude * math.sin(math.pi * amount / 2.0)
+        azimuth = _shortest_angle_lerp(sunrise_azimuth, noon_azimuth, amount)
+    else:
+        span = (sunset - solar_noon).total_seconds()
+        amount = _clamp((local - solar_noon).total_seconds() / span)
+        altitude = noon_altitude * math.cos(math.pi * amount / 2.0)
+        azimuth = _shortest_angle_lerp(noon_azimuth, sunset_azimuth, amount)
+
+    altitude_radians = math.radians(altitude)
+    relative_azimuth = math.radians(_wrap_degrees(azimuth - view_azimuth))
+    elevation = math.sin(altitude_radians)
+    x = 0.34 * math.cos(altitude_radians) * math.sin(relative_azimuth)
+    y = 0.18 - 0.42 * elevation
+    return x, y, elevation
+
+
+def _sun_state(
+    now: datetime, astronomy: Astronomy, view_azimuth: Optional[float] = None
+) -> Tuple[bool, float, float, float, float, float]:
+    zone = _zone(astronomy.timezone)
+    local = now.astimezone(zone)
+    if astronomy.sun_status == "polar_night":
+        return False, 0.0, -0.34, 0.18, 0.0, 0.0
+    if astronomy.sun_status == "midnight_sun":
+        midnight = datetime.combine(local.date(), time.min, zone)
+        progress = _clamp((local - midnight).total_seconds() / 86400.0)
+        elevation = 0.55 + 0.45 * math.sin(math.pi * progress) ** 2
+        x = 0.34 * math.sin(2.0 * math.pi * (progress - 0.25))
+        y = 0.05 - 0.25 * elevation
+        return True, progress, x, y, 1.0, elevation
+
+    legacy = _legacy_sun_state(local, astronomy)
+    geographic = _geographic_sun_position(local, astronomy, view_azimuth)
+    if geographic is None:
+        return legacy
+    visible, progress, _, _, opacity, _ = legacy
+    x, y, elevation = geographic
+    return visible, progress, x, y, opacity, elevation
 
 
 def _moon_interval_progress(
@@ -543,12 +640,14 @@ def _moon_interval_progress(
     return False, 0.0
 
 
-def compute_scene_state(now: datetime, astronomy: Astronomy) -> SceneState:
+def compute_scene_state(
+    now: datetime, astronomy: Astronomy, view_azimuth: Optional[float] = None
+) -> SceneState:
     if now.tzinfo is None:
         raise ValueError("now must be timezone-aware")
     phase, phase_blend, ambient, colorfulness, stars, city, looks = _lighting_at(now, astronomy)
     sun_visible, sun_progress, sun_x, sun_y, sun_opacity, solar_elevation = _sun_state(
-        now, astronomy
+        now, astronomy, view_azimuth
     )
     moon_visible, moon_progress = _moon_interval_progress(now, astronomy)
     moon_elevation = math.sin(math.pi * moon_progress) if moon_visible else 0.0
@@ -1537,12 +1636,7 @@ def neutral_astronomy(requested_day: date, timezone_name: str) -> Astronomy:
         moonset=None,
         moon_phase="New Moon",
         moon_illumination=0.0,
-        solar_position={
-            "sunrise_azimuth": 90.0,
-            "sunset_azimuth": 270.0,
-            "solar_noon_azimuth": 180.0,
-            "solar_noon_altitude": 45.0,
-        },
+        solar_position={},
         source="fallback",
     )
 
@@ -1677,6 +1771,16 @@ def _aware_datetime(value: str) -> datetime:
     return parsed
 
 
+def _azimuth_argument(value: str) -> float:
+    try:
+        result = float(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a number from 0 through 360") from error
+    if not math.isfinite(result) or not 0.0 <= result <= 360.0:
+        raise argparse.ArgumentTypeError("must be a number from 0 through 360")
+    return result
+
+
 def _location_json(location: Location) -> Mapping[str, Any]:
     result = location.to_mapping()
     result["source"] = location.source
@@ -1746,6 +1850,14 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--longitude", type=float)
     parser.add_argument("--timezone", dest="timezone_name")
     parser.add_argument("--locality", default="Manual location")
+    parser.add_argument(
+        "--view-azimuth",
+        type=_azimuth_argument,
+        help=(
+            "viewer-facing compass azimuth in degrees, 0..360; "
+            "defaults to solar-noon azimuth"
+        ),
+    )
     parser.add_argument("--interval", type=int, default=60, help="loop interval, 15..3600 seconds")
     parser.add_argument(
         "--demo-seconds",
@@ -1788,7 +1900,7 @@ def _preview(arguments: argparse.Namespace, now: datetime) -> Mapping[str, Any]:
         location = manual_location(latitude, longitude, timezone_name, arguments.locality)
     local_day = now.astimezone(_zone(location.timezone)).date()
     astronomy = neutral_astronomy(local_day, location.timezone)
-    state = compute_scene_state(now, astronomy)
+    state = compute_scene_state(now, astronomy, arguments.view_azimuth)
     managed = assumed_managed_layers(arguments.example_dir)
     commands = build_ipc_commands(managed, state, plan_asset_paths(managed))
     return {
@@ -1839,13 +1951,17 @@ def _run_demo_day(
             simulated = day_start + timedelta(days=1) - timedelta(microseconds=1)
         else:
             simulated = day_start + timedelta(seconds=SECONDS_PER_DAY * progress)
-        state = compute_scene_state(simulated, facts.astronomy)
+        state = compute_scene_state(
+            simulated, facts.astronomy, arguments.view_azimuth
+        )
         commands = controller.apply_once(state)
         payload = {
             "mode": "demo-day",
             "simulated_at": simulated.isoformat(),
             "progress": round(progress, 6),
             "phase": state.phase,
+            "sun_x": round(state.sun_x, 6),
+            "sun_y": round(state.sun_y, 6),
             "commands_applied": len(commands),
             "location_source": facts.location_source,
             "astronomy_source": facts.astronomy_source,
@@ -1913,7 +2029,9 @@ def main(
             payload = {
                 "mode": "status",
                 "facts": _facts_json(facts),
-                "state": _state_json(compute_scene_state(now, facts.astronomy)),
+                "state": _state_json(
+                    compute_scene_state(now, facts.astronomy, arguments.view_azimuth)
+                ),
             }
             print(json.dumps(payload, sort_keys=True))
             return 0
@@ -1931,7 +2049,9 @@ def main(
             now = current_time()
             try:
                 facts = _resolve(arguments, cache, client, now)
-                state = compute_scene_state(now, facts.astronomy)
+                state = compute_scene_state(
+                    now, facts.astronomy, arguments.view_azimuth
+                )
                 commands = controller.apply_once(state)
                 payload = {
                     "mode": "loop" if arguments.loop else "once",

--- a/tests/test_pixel_city_dynamic.py
+++ b/tests/test_pixel_city_dynamic.py
@@ -492,8 +492,100 @@ class SceneModelTests(unittest.TestCase):
         sunset = SCENE.compute_scene_state(
             self.local("2026-07-12T20:40:00+02:00"), astronomy
         )
-        self.assertAlmostEqual(-0.34, sunrise.sun_x)
-        self.assertAlmostEqual(0.34, sunset.sun_x)
+        self.assertLess(sunrise.sun_x, 0.0)
+        self.assertGreater(sunset.sun_x, 0.0)
+
+    def test_solar_noon_is_centered_by_default(self):
+        astronomy = self.astronomy()
+        state = SCENE.compute_scene_state(astronomy.solar_noon, astronomy)
+        self.assertAlmostEqual(0.0, state.sun_x, places=12)
+        self.assertAlmostEqual(
+            0.18 - 0.42 * SCENE.math.sin(SCENE.math.radians(63.2)),
+            state.sun_y,
+            places=12,
+        )
+
+    def test_noon_altitude_controls_seasonal_arc_height(self):
+        astronomy = self.astronomy()
+        winter = replace(
+            astronomy,
+            solar_position={**astronomy.solar_position, "solar_noon_altitude": 15.0},
+        )
+        summer = replace(
+            astronomy,
+            solar_position={**astronomy.solar_position, "solar_noon_altitude": 75.0},
+        )
+        winter_state = SCENE.compute_scene_state(astronomy.solar_noon, winter)
+        summer_state = SCENE.compute_scene_state(astronomy.solar_noon, summer)
+        self.assertGreater(winter_state.sun_y, summer_state.sun_y)
+        self.assertGreater(winter_state.sun_y - summer_state.sun_y, 0.20)
+
+    def test_horizon_azimuths_control_sunrise_and_sunset_positions(self):
+        astronomy = self.astronomy()
+        west_facing = replace(
+            astronomy,
+            solar_position={
+                **astronomy.solar_position,
+                "sunrise_azimuth": 180.0,
+                "sunset_azimuth": 180.0,
+            },
+        )
+        base_sunrise = SCENE.compute_scene_state(astronomy.sunrise, astronomy)
+        base_sunset = SCENE.compute_scene_state(astronomy.sunset, astronomy)
+        changed_sunrise = SCENE.compute_scene_state(west_facing.sunrise, west_facing)
+        changed_sunset = SCENE.compute_scene_state(west_facing.sunset, west_facing)
+        self.assertLess(base_sunrise.sun_x, -0.20)
+        self.assertGreater(base_sunset.sun_x, 0.20)
+        self.assertAlmostEqual(0.0, changed_sunrise.sun_x, places=12)
+        self.assertAlmostEqual(0.0, changed_sunset.sun_x, places=12)
+
+    def test_shortest_angle_interpolation_crosses_zero(self):
+        self.assertAlmostEqual(355.0, SCENE._shortest_angle_lerp(350.0, 10.0, 0.25))
+        self.assertAlmostEqual(0.0, SCENE._shortest_angle_lerp(350.0, 10.0, 0.5))
+        self.assertAlmostEqual(5.0, SCENE._shortest_angle_lerp(350.0, 10.0, 0.75))
+
+    def test_geographic_trajectory_is_continuous_at_solar_noon(self):
+        astronomy = self.astronomy()
+        before = SCENE.compute_scene_state(
+            astronomy.solar_noon - timedelta(microseconds=1), astronomy
+        )
+        at_noon = SCENE.compute_scene_state(astronomy.solar_noon, astronomy)
+        after = SCENE.compute_scene_state(
+            astronomy.solar_noon + timedelta(microseconds=1), astronomy
+        )
+        self.assertLess(abs(before.sun_x - at_noon.sun_x), 1e-8)
+        self.assertLess(abs(after.sun_x - at_noon.sun_x), 1e-8)
+        self.assertLess(abs(before.sun_y - after.sun_y), 1e-10)
+
+    def test_missing_or_invalid_position_data_uses_legacy_trajectory(self):
+        astronomy = self.astronomy()
+        now = astronomy.sunrise + timedelta(hours=2)
+        span = (astronomy.sunset - astronomy.sunrise).total_seconds()
+        progress = (now - astronomy.sunrise).total_seconds() / span
+        expected_x = -0.34 + 0.68 * progress
+        expected_y = 0.18 - 0.42 * SCENE.math.sin(SCENE.math.pi * progress)
+        cases = (
+            {},
+            {**astronomy.solar_position, "solar_noon_altitude": None},
+            {**astronomy.solar_position, "solar_noon_altitude": float("nan")},
+            {**astronomy.solar_position, "sunrise_azimuth": -1.0},
+        )
+        for solar_position in cases:
+            with self.subTest(solar_position=solar_position):
+                state = SCENE.compute_scene_state(
+                    now, replace(astronomy, solar_position=solar_position)
+                )
+                self.assertAlmostEqual(expected_x, state.sun_x)
+                self.assertAlmostEqual(expected_y, state.sun_y)
+
+    def test_explicit_view_azimuth_changes_projection_but_not_bounds(self):
+        astronomy = self.astronomy()
+        state = SCENE.compute_scene_state(
+            astronomy.solar_noon, astronomy, view_azimuth=90.0
+        )
+        self.assertGreater(state.sun_x, 0.10)
+        self.assertTrue(-0.34 <= state.sun_x <= 0.34)
+        self.assertTrue(-0.24 <= state.sun_y <= 0.18)
 
     def test_cross_midnight_moon_visibility_and_bounds(self):
         astronomy = self.astronomy()
@@ -563,10 +655,18 @@ class SceneModelTests(unittest.TestCase):
         )
         night_state = SCENE.compute_scene_state(FIXED_NOW, polar_night)
         day_state = SCENE.compute_scene_state(FIXED_NOW, midnight_sun)
+        shifted_night = SCENE.compute_scene_state(
+            FIXED_NOW, polar_night, view_azimuth=270.0
+        )
+        shifted_day = SCENE.compute_scene_state(
+            FIXED_NOW, midnight_sun, view_azimuth=270.0
+        )
         self.assertEqual("night", night_state.phase)
         self.assertFalse(night_state.sun_visible)
         self.assertEqual("high_noon", day_state.phase)
         self.assertTrue(day_state.sun_visible)
+        self.assertEqual(night_state, shifted_night)
+        self.assertEqual(day_state, shifted_day)
 
     def test_normal_missing_solar_fields_use_neutral_anchors(self):
         missing = replace(
@@ -939,6 +1039,9 @@ class IPCControllerTests(unittest.TestCase):
             ("--demo-seconds", "0"),
             ("--demo-step", "0.1"),
             ("--demo-day", "--demo-seconds", "1", "--demo-step", "2"),
+            ("--view-azimuth", "-0.1"),
+            ("--view-azimuth", "360.1"),
+            ("--view-azimuth", "nan"),
             ("--latitude", "47.5"),
             ("--at", "2026-07-12T12:00:00"),
         ):
@@ -984,7 +1087,7 @@ class IPCControllerTests(unittest.TestCase):
                 (
                     "--loop", "--at", "2026-07-12T12:00:00+02:00",
                     "--latitude", "47.4979", "--longitude", "19.0402",
-                    "--timezone", "Europe/Budapest",
+                    "--timezone", "Europe/Budapest", "--view-azimuth", "90",
                     "--cache", str(Path(self.temporary.name) / "loop.json"),
                     "--example-dir", str(self.example), "--interval", "15",
                 ),
@@ -1009,7 +1112,7 @@ class IPCControllerTests(unittest.TestCase):
                     "--demo-day", "--demo-seconds", "4", "--demo-step", "1",
                     "--at", "2026-07-12T12:00:00+02:00",
                     "--latitude", "47.4979", "--longitude", "19.0402",
-                    "--timezone", "Europe/Budapest",
+                    "--timezone", "Europe/Budapest", "--view-azimuth", "90",
                     "--cache", str(Path(self.temporary.name) / "demo.json"),
                     "--example-dir", str(self.example),
                 ),
@@ -1027,6 +1130,9 @@ class IPCControllerTests(unittest.TestCase):
         self.assertTrue(all(payload["mode"] == "demo-day" for payload in payloads))
         self.assertIn("night", {payload["phase"] for payload in payloads})
         self.assertIn("late_afternoon", {payload["phase"] for payload in payloads})
+        noon_frame = payloads[2]
+        self.assertGreater(noon_frame["sun_x"], 0.10)
+        self.assertTrue(-0.24 <= noon_frame["sun_y"] <= 0.18)
         self.assertEqual([1.0, 1.0, 1.0, 1.0], clock.sleeps)
         self.assertEqual(1, len(client.calls))
         self.assertIn("sunrise-sunset.org", client.calls[0])
@@ -1045,10 +1151,13 @@ class DocumentationTests(unittest.TestCase):
             "--once",
             "--loop --interval 60",
             "--demo-day --demo-seconds 60 --demo-step 1",
+            "--view-azimuth",
             "--latitude 47.4979 --longitude 19.0402 --timezone Europe/Budapest",
             "managed layers missing from daemon",
             "systemctl --user import-environment",
             "systemctl --user enable --now",
+            "2D side projection",
+            "legacy static trajectory",
         ):
             with self.subTest(required=required):
                 self.assertIn(required, self.readme)


### PR DESCRIPTION
## Summary

Follow-up to #94 after its merge.

- replace the normal-day static left-to-right sun arc with a geographically informed 2D side projection
- derive altitude piecewise across sunrise to solar noon to sunset and interpolate azimuth along the shortest angular path across 0/360 degrees
- default the view bearing to solar-noon azimuth so noon is horizontally centered
- add validated `--view-azimuth 0..360` control and pass it through once, loop, status, and demo-day modes
- preserve visibility, horizon opacity, inverse UV coordinates, IPC ownership/deltas, caching, generated assets, mock-clock cadence, polar night, and midnight sun
- retain the legacy static trajectory whenever required timestamps or solar-position values are missing, non-finite, out of range, or chronologically invalid
- document projection geometry, view bearings, fallback behavior, and a complete full-day tuning command

## Regression coverage

The Dynamic Pixel City suite now proves:

- solar noon centers by default
- low winter and high summer noon altitudes produce shallower and taller arcs
- sunrise and sunset azimuths control horizon positions
- 350 degrees to 10 degrees crosses through 0 degrees
- both piecewise halves are continuous at solar noon
- generated coordinates stay inside existing SceneState bounds
- missing and invalid position inputs use the exact legacy arc
- polar night and midnight sun remain deterministic
- demo-day propagates the geographic view projection
- invalid view azimuth values fail argument parsing

## Verification

- clean `make`: exit 0; existing C warnings unchanged
- `make test-scripts`: 56 Dynamic Pixel City tests plus every shell suite pass
- Python compilation: `dynamic_scene.py` and its test module compile
- `make lint`: exit 0; existing unrelated cppcheck warnings remain
- `git diff --check`: clean
- live 60-second `--demo-day`: cache used once, progress reached 1.0, all named phases crossed, projected sun telemetry remained bounded and continuous, no provider or IPC errors
- service choreography: normal controller stopped before demo and restored afterward by trap
- local runtime after demo/deploy: wallpaper service active, controller service active, Hyprlax reports 9 layers
- deployed controller SHA-256 matches source: `9865b133127eb6a2975896bae29641f088d31f1a531a568a413baba429db2fb5`

## Delivery

Head commit: `4fe64bb96b7db3e53a0d8b798fc66b22356487ed`
